### PR TITLE
OPTION 1: Chatlockdown workaround for encounters

### DIFF
--- a/Core/Interoperability/LibSink/Output.lua
+++ b/Core/Interoperability/LibSink/Output.lua
@@ -3,7 +3,18 @@ local Output = {}
 function Output:DisplayText(text, icon)
 	-- Arguments: text, r, g, b, font, size, outline, sticky, location, icon (though most appear to be useless?)
 	-- Note: Provide r,g,b as float, i.e., in the interval [0.0, 1.0]
-	Rarity:Pour(text, nil, nil, nil, nil, nil, nil, nil, nil, icon)
+	if not text or text == "" then
+		return
+	end
+
+	local displayText = text
+	if icon then
+		displayText = "|T" .. icon .. ":15:15:0:0:64:64:4:60:4:60|t " .. displayText
+	end
+
+	if DEFAULT_CHAT_FRAME and DEFAULT_CHAT_FRAME.AddMessage then
+		DEFAULT_CHAT_FRAME:AddMessage(displayText, 1, 1, 1)
+	end
 end
 
 function Output:GetOptionsTable()


### PR DESCRIPTION
Failure to push the chat message for ''item: x attempts'' upon kill of bosses like Swampface (Floodgate) and HK8 (Mechagon) prevented it from counting an attempt on their respective collectibles (craboom, mechagon peacekeeper). Likely caused by a Midnight API change that puts chat in Lockdown during encounters. Strangely doesn't affect all dungeon encounters? Tazavesh was fine for one.

Anyway, this change adds a guard for nil returns and prevents running into protected functions. 

However - This adds a new problem. Party and Raid chat messages from Rarity can no longer be supported like this due to the CHATLOCKDOWN. But it will still push messages even while in an encounter this way.

https://warcraft.wiki.gg/wiki/API_InCombatLockdown
https://warcraft.wiki.gg/wiki/API_C_ChatInfo.InChatMessagingLockdown