### PR TITLE
OPTION 2: Chatlockdown workaround for encounters

### DIFF
--- a/Core/Interoperability/LibSink/Output.lua
+++ b/Core/Interoperability/LibSink/Output.lua
@@ -3,6 +3,16 @@ local Output = {}
 function Output:DisplayText(text, icon)
 	-- Arguments: text, r, g, b, font, size, outline, sticky, location, icon (though most appear to be useless?)
 	-- Note: Provide r,g,b as float, i.e., in the interval [0.0, 1.0]
+	if not text or text == "" then
+		return
+	end
+
+	-- Skip output during combat lockdown to avoid protected function errors
+	if InCombatLockdown() then
+		return
+	end
+
+	-- Use user-decided channels via Rarity:Pour
 	Rarity:Pour(text, nil, nil, nil, nil, nil, nil, nil, nil, icon)
 end
 


### PR DESCRIPTION
Failure to push the chat message for ''item: x attempts'' upon kill of bosses like Swampface (Floodgate) and HK8 (Mechagon) prevented it from counting an attempt on their respective collectibles (craboom, mechagon peacekeeper). Likely caused by a Midnight API change that puts chat in Lockdown during encounters. Strangely doesn't affect all dungeon encounters? Tazavesh was fine for one.

This change prevents it from even trying to push any form of chat message while in CombatLockdown. This pushes no chat message but still adds an attempt, just quietly.

https://warcraft.wiki.gg/wiki/API_InCombatLockdown
https://warcraft.wiki.gg/wiki/API_C_ChatInfo.InChatMessagingLockdown