### PR TITLE
Fix max character limit for edit box in CopyPastePopup.lua

### DIFF
--- a/Core/GUI/CopyPastePopup.lua
+++ b/Core/GUI/CopyPastePopup.lua
@@ -35,6 +35,7 @@ function CopyPastePopup:ConfigureStaticPopUp()
 		end
 		popup.OnShow = function(frame, data)
 			local editBox = frame.GetEditBox and frame:GetEditBox() or frame.editBox
+			editBox:SetMaxLetters(0)
 			editBox:SetText(text)
 			editBox:SetJustifyH("CENTER")
 			editBox:SetWidth(240)

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -322,7 +322,7 @@ function R:PrepareOptions()
 								desc = L["You can follow the development process or contribute to the project on our public GitHub repository. What could be more fun than browsing a gigantic backlog of unresolved issues?"],
 								func = function(info)
 									Rarity.CopyPastePopup:SetEditBoxText(
-										"https://github.com/aSnejbjerg/Rarity-Collectors-edition" 
+										"https://github.com/aSnejbjerg/Rarity-Collectors-edition"
 									)
 									Rarity.CopyPastePopup:Show()
 								end,

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -322,7 +322,7 @@ function R:PrepareOptions()
 								desc = L["You can follow the development process or contribute to the project on our public GitHub repository. What could be more fun than browsing a gigantic backlog of unresolved issues?"],
 								func = function(info)
 									Rarity.CopyPastePopup:SetEditBoxText(
-										"https://github.com/aSnejbjerg/Rarity-Collectors-edition"
+										"https://github.com/aSnejbjerg/Rarity-Collectors-edition" 
 									)
 									Rarity.CopyPastePopup:Show()
 								end,


### PR DESCRIPTION
Contribute on GitHub button would only allow "https://github.com/aSnejbjerg/Ra" text to be displayed and copyable
<img width="428" height="144" alt="image" src="https://github.com/user-attachments/assets/c0823218-205b-44ea-b88b-59f91ca8982e" />

With this fix the text is now fully inserted 

<img width="424" height="157" alt="image" src="https://github.com/user-attachments/assets/5caf9504-6c38-4685-b3e5-a56e9aafbc23" />
