### PR TITLE
Add spellId for Nether-Warped Egg item

### DIFF
--- a/DB/Mounts/Midnight.lua
+++ b/DB/Mounts/Midnight.lua
@@ -80,6 +80,7 @@ local midnightMounts = {
 		name = L["Nether-Warped Egg"],
 		itemId = 268730,
 		chance = 2500,
+		spellId = 3363,
 		sourceText = L["This item drops the Nether-Swept Drake mount after 7 days."],
 		coords = {
 			{ m = CONSTANTS.UIMAPIDS.EVERSONG_WOODS_MIDNIGHT },


### PR DESCRIPTION
Adding spell ID for drake you get from the Nether-Warped Egg makes it Rarity can detect it