### PR TITLE
Replace the last UIParentLoadAddOn call (removed in 12.1.0)

### DIFF
--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -10,6 +10,7 @@ local GetItemInfo = _G.C_Item.GetItemInfo
 local GetBestMapForUnit = C_Map.GetBestMapForUnit
 local IsWorldQuestActive = C_TaskQuest.IsActive
 local IsQuestFlaggedCompleted = _G.C_QuestLog.IsQuestFlaggedCompleted
+local LoadAddOn = _G.C_AddOns.LoadAddOn
 local C_Covenants = _G.C_Covenants
 
 local FormatTime = Rarity.Utils.PrettyPrint.FormatTime
@@ -1155,7 +1156,7 @@ local function addGroup(group, requiresGroup)
 										Rarity:Print(text)
 										if CVarCallbackRegistry:GetCVarValueBool("enableFloatingCombatText") then
 											if type(CombatText_AddMessage) == "nil" then
-												UIParentLoadAddOn("Blizzard_CombatText")
+												LoadAddOn("Blizzard_CombatText")
 											end
 											CombatText_AddMessage(text, CombatText_StandardScroll, 1, 1, 1, true, false)
 										else


### PR DESCRIPTION
Patch 12.1.0 renamed the global `UIParentLoadAddOn` to `LoadAddOnWithErrorHandling` and left the old name `nil` ([12.1.0 API changes](https://warcraft.wiki.gg/wiki/Patch_12.1.0/API_changes)). Confirmed on live 12.1.0:

```
/dump type(UIParentLoadAddOn), type(LoadAddOnWithErrorHandling), type(C_AddOns.LoadAddOn)
[1]="nil", [2]="function", [3]="function"
```

`Core/Collections.lua` was already handled; `MainWindow.lua:1158` is the last caller. It's latent rather than fatal — it only runs on the holiday-reminder path with `enableFloatingCombatText` enabled and a holiday item due that day — but it's a guaranteed `attempt to call a nil value` when it does run.

Uses `C_AddOns.LoadAddOn` rather than `LoadAddOnWithErrorHandling` because it exists on retail *and* on every Classic flavour the TOC targets, so no name-fallback chain is needed, and it's already the idiom in seven other files (`Core.lua:113`, `Core/GUI.lua:34`, `Core/Profiling.lua:6`, …). The behavioural difference is that it returns `success, reason` instead of popping an error dialog, which is what the surrounding code already expects.

`stylua --check .` (v0.17.1) and luacheck (v1.2.0) are clean.