### PR TITLE
Scroll the tooltip by whole rows instead of 10 pixels

### DIFF
--- a/Core/Interoperability/LibQTip/Tooltips.lua
+++ b/Core/Interoperability/LibQTip/Tooltips.lua
@@ -6,13 +6,32 @@ local Tooltips = {}
 -- Dependencies are loaded before any of our own files, so it should be safe to cache it on load
 local LibQTip = LibStub("LibQTip-1.0")
 
+-- LibQTip scrolls by 10 pixels per wheel click, which is less than the height of a single row: the
+-- collection list barely moves. Scroll by whole rows instead, derived from the tooltip's own font so
+-- it keeps up if the font size changes.
+local SCROLL_ROWS_PER_WHEEL_CLICK = 3
+local FALLBACK_FONT_HEIGHT = 12 -- GameTooltipText's height, if the font object won't report one
+local ROW_SPACING = 3 -- LibQTip's CELL_MARGIN_V, the vertical gap it puts between rows
+
+local function SetScrollStepInRows(tooltip, rows)
+	local font = tooltip.GetFont and tooltip:GetFont()
+	local _, fontHeight = font and font:GetFont()
+
+	tooltip:SetScrollStep(rows * ((fontHeight or FALLBACK_FONT_HEIGHT) + ROW_SPACING))
+end
+
 function Tooltips:IsTooltipAcquired(tooltipName)
 	return LibQTip:IsAcquired(tooltipName)
 end
 
 -- TODO Separate acquire from create and don't forward varargs here
 function Tooltips:AcquireTooltip(tooltipName, ...)
-	return LibQTip:Acquire(tooltipName, ...)
+	local tooltip = LibQTip:Acquire(tooltipName, ...)
+
+	-- LibQTip clears the scroll step when a tooltip is released, so this has to be set on every acquire
+	SetScrollStepInRows(tooltip, SCROLL_ROWS_PER_WHEEL_CLICK)
+
+	return tooltip
 end
 
 function Tooltips:ReleaseTooltip(tooltipName)


### PR DESCRIPTION
Scrolling the collection list with the mouse wheel is painfully slow — one click barely moves the list at all, so paging through a large collection takes forever.

**Cause:** LibQTip's wheel handler moves the slider by `self.step or 10` ([LibQTip-1.0.lua:726-737](https://repos.wowace.com/wow/libqtip-1-0/trunk/LibQTip-1.0.lua)), and Rarity never calls `SetScrollStep`, so every tooltip is stuck on the 10 pixel default. A row is taller than that, so one wheel click doesn't even advance a full line.

**Fix:** set the step to three rows when a tooltip is acquired.

Three small decisions, happy to change any of them:

- **Derived from the font rather than a hard-coded pixel count.** `tooltip:GetFont()` gives the height, plus LibQTip's 3px `CELL_MARGIN_V` row spacing. If the font size ever changes the step follows instead of drifting.
- **Done in `Tooltips:AcquireTooltip` rather than at each call site.** LibQTip clears `.step` on release (`LibQTip-1.0.lua:439`), so it has to be re-set on every acquire — and doing it centrally means the main window, the quicktip and the sub-tooltip all behave consistently.
- **Three rows** to match the usual convention elsewhere in the UI. Trivial to change the constant, or to hang it off a slider in the tooltip options group if you'd rather it were configurable — say the word and I'll add it.

Nothing in `Libs/` is touched, since that gets replaced from wowace at package time anyway.

### Testing

Verified in-game on 12.1.0 with Rarity CE v0.2.1: the wheel now moves the list about three rows per click in the main window, and the sub-tooltips scroll the same way. No change to any other tooltip behaviour. `stylua --check .` (v0.17.1, matching CI) and luacheck (v1.2.0) are both clean.

### Note on my other PR

This is cut fresh from `default` and is independent of #78 — deliberately no overlap in files, so the two can merge in either order without conflicting.