### PR TITLE
fixed fishing detection

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -174,6 +174,11 @@ function R:OnSpellcastSucceeded(event, unitID, castGUID, spellID)
 
 	R:Debug("OnSpellcastSucceeded triggered with relevant spell " .. spellID)
 
+	-- Fishing is an instant cast, so UNIT_SPELLCAST_START does not fire for it.
+	if Rarity.relevantSpells[spellID] == "Fishing" then
+		self:OnSpellcastSent(event, unitID, castGUID, spellID)
+	end
+
 	if IsPlayerInHorrificVision() and spellID == 312881 then
 		self:Debug("Finished searching mailbox in a Horrific Vision")
 		addAttemptForItem("Mail Muncher", "mounts")


### PR DESCRIPTION
af48025dd97436382bc1844eca526b80fbbfc797 broke the fishing detection

UNIT_SPELLCAST_START only fires for non-instant casts, while the old UNIT_SPELLCAST_SENT fired for instant casts too. Fishing uses the instant-cast path, which means the spell ID 131474 (that's the fishing spell ID) is never delivered to the handler after the commit