### PR TITLE
Ral'kala tracking & Preyhunters Masquerade added

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -397,6 +397,58 @@ do
 	end
 end
 
+-------------------------------------------------------------------------------------
+-- Handle boss kills. You may not ever open a loot window on a boss, so we need to watch the combat log for its death.
+-- This event also handles some special cases.
+-------------------------------------------------------------------------------------
+-- function R:OnCombat()
+-- 	self.Profiling:StartTimer("EventHandlers.OnCombat")
+
+-- 	-- Extract event payload (it's no longer being passed by the event iself as of 8.0.1)
+-- 	local timestamp, eventType, hideCaster, srcGuid, srcName, srcFlags, srcRaidFlags, dstGuid, dstName, dstFlags, dstRaidFlags, spellId, spellName, spellSchool, auraType =
+-- 		CombatLogGetCurrentEventInfo()
+
+-- 	if eventType == "UNIT_DIED" then -- A unit died near you
+-- 		local npcid = self:GetNPCIDFromGUID(dstGuid)
+-- 		if Rarity.bosses[npcid] then -- It's a boss we're interested in
+-- 			R:Debug("Detected UNIT_DIED for relevant NPC with ID = " .. tostring(npcid))
+-- 			if
+-- 				bit_band(srcFlags, COMBATLOG_OBJECT_AFFILIATION_MINE)
+-- 				or bit_band(srcFlags, COMBATLOG_OBJECT_AFFILIATION_PARTY)
+-- 				or bit_band(srcFlags, COMBATLOG_OBJECT_AFFILIATION_RAID)
+-- 			then -- You, a party member, or a raid member killed it
+-- 				if not Rarity.guids[dstGuid] then
+-- 					if not UnitAffectingCombat("player") and not UnitIsDead("player") then
+-- 						Rarity:Debug("Ignoring this UNIT_DIED event because the player is alive, but not in combat")
+-- 						self.Profiling:EndTimer("EventHandlers.OnCombat")
+-- 						return
+-- 					end
+
+-- 					-- Increment attempts counter(s). One NPC might drop multiple things we want, so scan for them all.
+-- 					if Rarity.npcs_to_items[npcid] and type(Rarity.npcs_to_items[npcid]) == "table" then
+-- 						for k, v in pairs(Rarity.npcs_to_items[npcid]) do
+-- 							local isBossDrop = (v.method == CONSTANTS.DETECTION_METHODS.BOSS)
+-- 							local hasKillStatistics = type(v.statisticId) ~= "nil"
+-- 							if v.enabled ~= false and isBossDrop and not hasKillStatistics then
+-- 								if self:IsAttemptAllowed(v) then
+-- 									Rarity.guids[dstGuid] = true
+-- 									if v.attempts == nil then
+-- 										v.attempts = 1
+-- 									else
+-- 										v.attempts = v.attempts + 1
+-- 									end
+-- 									self:OutputAttempts(v)
+-- 								end
+-- 							end
+-- 						end
+-- 					end
+-- 				end
+-- 			end
+-- 		end
+-- 	end
+-- 	self.Profiling:EndTimer("EventHandlers.OnCombat")
+-- end
+
 local RALKALA_CONTRIBUTION_AURA_ID = 1305910
 local ralkalaAttemptTimer
 local ralkalaDrops = {

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -86,6 +86,7 @@ function EventHandlers:Register()
 	self:RegisterEvent("ISLAND_COMPLETED", "OnIslandCompleted")
 	self:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED", "OnSpellcastSucceeded")
 	self:RegisterEvent("QUEST_TURNED_IN", "OnQuestTurnedIn")
+	self:RegisterEvent("UNIT_AURA", "OnUnitAura")
 
 	if LE_EXPANSION_LEVEL_CURRENT >= LE_EXPANSION_MISTS_OF_PANDARIA then
 		self:RegisterEvent("SHOW_LOOT_TOAST", "OnShowLootToast")
@@ -396,57 +397,39 @@ do
 	end
 end
 
--------------------------------------------------------------------------------------
--- Handle boss kills. You may not ever open a loot window on a boss, so we need to watch the combat log for its death.
--- This event also handles some special cases.
--------------------------------------------------------------------------------------
--- function R:OnCombat()
--- 	self.Profiling:StartTimer("EventHandlers.OnCombat")
+local RALKALA_CONTRIBUTION_AURA_ID = 1305910
+local ralkalaAttemptTimer
+local ralkalaDrops = {
+	{ name = "Pale Hexscale", category = "pets" },
+	{ name = "Hexflame Reaver", category = "mounts" },
+	{ name = "Preyhunter's Masquerade", category = "toys" },
+}
 
--- 	-- Extract event payload (it's no longer being passed by the event iself as of 8.0.1)
--- 	local timestamp, eventType, hideCaster, srcGuid, srcName, srcFlags, srcRaidFlags, dstGuid, dstName, dstFlags, dstRaidFlags, spellId, spellName, spellSchool, auraType =
--- 		CombatLogGetCurrentEventInfo()
+local function addRalkalaAttempts(self)
+	self:Debug("Detected personal attack on Ral'kala (Prey hunt) - adding attempts for its drops")
+	for _, drop in ipairs(ralkalaDrops) do
+		addAttemptForItem(drop.name, drop.category)
+	end
+end
 
--- 	if eventType == "UNIT_DIED" then -- A unit died near you
--- 		local npcid = self:GetNPCIDFromGUID(dstGuid)
--- 		if Rarity.bosses[npcid] then -- It's a boss we're interested in
--- 			R:Debug("Detected UNIT_DIED for relevant NPC with ID = " .. tostring(npcid))
--- 			if
--- 				bit_band(srcFlags, COMBATLOG_OBJECT_AFFILIATION_MINE)
--- 				or bit_band(srcFlags, COMBATLOG_OBJECT_AFFILIATION_PARTY)
--- 				or bit_band(srcFlags, COMBATLOG_OBJECT_AFFILIATION_RAID)
--- 			then -- You, a party member, or a raid member killed it
--- 				if not Rarity.guids[dstGuid] then
--- 					if not UnitAffectingCombat("player") and not UnitIsDead("player") then
--- 						Rarity:Debug("Ignoring this UNIT_DIED event because the player is alive, but not in combat")
--- 						self.Profiling:EndTimer("EventHandlers.OnCombat")
--- 						return
--- 					end
+function R:OnUnitAura(_, unit, updateInfo)
+	if unit ~= "player" or not updateInfo or not updateInfo.addedAuras then
+		return
+	end
 
--- 					-- Increment attempts counter(s). One NPC might drop multiple things we want, so scan for them all.
--- 					if Rarity.npcs_to_items[npcid] and type(Rarity.npcs_to_items[npcid]) == "table" then
--- 						for k, v in pairs(Rarity.npcs_to_items[npcid]) do
--- 							local isBossDrop = (v.method == CONSTANTS.DETECTION_METHODS.BOSS)
--- 							local hasKillStatistics = type(v.statisticId) ~= "nil"
--- 							if v.enabled ~= false and isBossDrop and not hasKillStatistics then
--- 								if self:IsAttemptAllowed(v) then
--- 									Rarity.guids[dstGuid] = true
--- 									if v.attempts == nil then
--- 										v.attempts = 1
--- 									else
--- 										v.attempts = v.attempts + 1
--- 									end
--- 									self:OutputAttempts(v)
--- 								end
--- 							end
--- 						end
--- 					end
--- 				end
--- 			end
--- 		end
--- 	end
--- 	self.Profiling:EndTimer("EventHandlers.OnCombat")
--- end
+	if issecretvalue and issecretvalue(updateInfo.addedAuras) then
+		return
+	end
+
+	for _, aura in ipairs(updateInfo.addedAuras) do
+		if aura and aura.spellId and not (issecretvalue and issecretvalue(aura.spellId)) then
+			if aura.spellId == RALKALA_CONTRIBUTION_AURA_ID then
+				addRalkalaAttempts(self)
+				return
+			end
+		end
+	end
+end
 
 local worldEventQuests = {
 	[52196] = "Slightly Damp Pile of Fur", -- Dunegorger Kraulok (TODO: Use encounter also?)

--- a/DB/Mounts/Midnight.lua
+++ b/DB/Mounts/Midnight.lua
@@ -487,19 +487,15 @@ midnightMounts["Topaz Skyfang"] = {
 midnightMounts["Hexflame Reaver"] = {
 	cat = CONSTANTS.ITEM_CATEGORIES.MIDNIGHT,
 	type = CONSTANTS.ITEM_TYPES.MOUNT,
-	method = CONSTANTS.DETECTION_METHODS.NPC,
+	method = CONSTANTS.DETECTION_METHODS.SPECIAL,
 	name = L["Hexflame Reaver"],
 	itemId = 275659,
 	spellId = 1297407,
 	npcs = { 258928 },
+	tooltipNpcs = { 258928 },
 	chance = 100,
-	coords = {
-		{ m = CONSTANTS.UIMAPIDS.VOIDSTORM },
-		{ m = CONSTANTS.UIMAPIDS.SILVERMOON },
-		{ m = CONSTANTS.UIMAPIDS.EVERSONG },
-		{ m = CONSTANTS.UIMAPIDS.HARANDAR },
-		{ m = CONSTANTS.UIMAPIDS.COILED_ISLES },
-	},
+	sourceText = L["Dropped by the prey boss named Ral'kala"],
+	coords = { { m = CONSTANTS.UIMAPIDS.COILED_ISLES } },
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.mounts, midnightMounts)

--- a/DB/Pets/Midnight.lua
+++ b/DB/Pets/Midnight.lua
@@ -130,13 +130,14 @@ midnightPets["Lil' Mon"] = {
 midnightPets["Pale Hexscale"] = {
 	cat = CONSTANTS.ITEM_CATEGORIES.MIDNIGHT,
 	type = CONSTANTS.ITEM_TYPES.PET,
-	method = CONSTANTS.DETECTION_METHODS.NPC,
+	method = CONSTANTS.DETECTION_METHODS.SPECIAL,
 	name = L["Pale Hexscale"],
 	creatureId = 269712,
 	itemId = 278572,
 	spellId = 1305199,
-	chance = 100,
+	chance = 33,
 	npcs = { 258928 },
+	tooltipNpcs = { 258928 },
 	sourceText = L["Dropped by the prey boss named Ral'kala"],
 	coords = { { m = CONSTANTS.UIMAPIDS.COILED_ISLES } },
 }

--- a/DB/Toys/Midnight.lua
+++ b/DB/Toys/Midnight.lua
@@ -176,6 +176,19 @@ midnightToys["Idol of Blue Water and Blue Sky"] = {
 	sourceText = L["Looted from a treasure named Abandoned Amani Privateer's Cache"],
 	coords = { { m = CONSTANTS.UIMAPIDS.COILED_ISLES } },
 }
+midnightToys["Preyhunter's Masquerade"] = {
+	cat = CONSTANTS.ITEM_CATEGORIES.MIDNIGHT,
+	type = CONSTANTS.ITEM_TYPES.ITEM,
+	isToy = true,
+	method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+	name = L["Preyhunter's Masquerade"],
+	itemId = 276207,
+	npcs = { 258928 },
+	tooltipNpcs = { 258928 },
+	chance = 33,
+	sourceText = L["Dropped by the prey boss named Ral'kala"],
+	coords = { { m = CONSTANTS.UIMAPIDS.COILED_ISLES } },
+}
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, midnightToys)
 return midnightToys

--- a/Locales.lua
+++ b/Locales.lua
@@ -10,6 +10,7 @@ L["Primevil Skyfriend"] = true
 L["Lil' Mon"] = true
 L["Dropped off a rare named Big Mon"] = true
 L["Pale Hexscale"] = true
+L["Preyhunter's Masquerade"] = true
 L["Dropped by the prey boss named Ral'kala"] = true
 L["Jaktu's Cursed Blade"] = true
 L["This item drops from the treasure Jaktu's Cursed Blade!"] = true


### PR DESCRIPTION
Changed the method from NPC to SPECIAL as I am highly suspecting Ral'kala is surrounded in secret values due to it being Endgame content.

Instead we completely ignore the NPC itself and track an attempt the moment you gain the ''Whispers from De Other Side'' buff, obtained by contributing with the Brazier. The buff is removed upon killing Ral'kala, so it should count accurately each time - If you did not participate in the kill, your next contribution will not count as you still have the buff.

On top of that we were missing the Preyhunter's Masquerade toy, so I added that too and linked it to the same method.

I think code could still use some looking at since I tried various methods and likely haven't cleaned it all up. I don't think we need the following anymore:

400 - local ralkalaAttemptTimer _(this was to delay contribution, but since we track the buff itself now and that disappears after kill, this is not needed.)_

This entire line might be adjustable, starting at 407, since its a leftover from combatlog tracking:

local function addRalkalaAttempts(self)
	self:Debug("Detected personal attack on Ral'kala (Prey hunt) - adding attempts for its drops")
	for _, drop in ipairs(ralkalaDrops) do
		addAttemptForItem(drop.name, drop.category)
	end
end

I'll leave the cleanup to someone else, I'm sure i left plenty of whitespaces :P 